### PR TITLE
Enable exclusion of blocks of YAML from the enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,36 @@ class User < ActiveRecord::Base
 end
 ```
 
+additional `yaml` syntax such as anchors can be removed from the enumeration by including `_exclude_from_enumeration`:
+
+```yaml
+# countries.yml
+---
+defaults_exclude_from_enumeration: &defaults
+  continent: Australia
+
+nz:
+  <<: *defaults
+  id: 1 # has to be provided
+  type: new_zealand # has to be provided
+  name: New Zealand
+  code: nz
+au:
+  <<: *defaults
+  id: 2
+  type: australia
+  name: Australia
+  code: au
+uk:
+  <<: *defaults
+  id: 3
+  type: united_kingdom
+  name: United Kingdom
+  code: uk
+  continent: Europe
+...
+```
+
 ## Accessing members
 
 If you include a call to class method `with_named_items` you will get an item defined for each typed entry in the enumeration, e.g. `Country.NEW_ZEALAND` and `Country.AUSTRALIA`.

--- a/lib/yaml_enumeration/enumeration.rb
+++ b/lib/yaml_enumeration/enumeration.rb
@@ -13,7 +13,7 @@ module YamlEnumeration
 
     def self.load_values(filename)
       file = File.join(Rails.root, 'db', 'enumerations', "#{filename}.yml")
-      YAML.load(ERB.new(File.read(file)).result).values.each do |data|
+      remove_exclusions(YAML.load(ERB.new(File.read(file)).result)).values.each do |data|
         value data.symbolize_keys
       end
     end
@@ -142,6 +142,11 @@ module YamlEnumeration
 
     def initialize(id)
       self.id = id
+    end
+
+    def remove_exclusions(result)
+      keys_to_remove = result.keys.select {|key| key =~ /.*_exclude_from_enumeration$/ }
+      result.except(*keys_to_remove)
     end
 
   end # Enumeration

--- a/lib/yaml_enumeration/enumeration.rb
+++ b/lib/yaml_enumeration/enumeration.rb
@@ -144,7 +144,7 @@ module YamlEnumeration
       self.id = id
     end
 
-    def remove_exclusions(result)
+    def self.remove_exclusions(result)
       keys_to_remove = result.keys.select {|key| key =~ /.*_exclude_from_enumeration$/ }
       result.except(*keys_to_remove)
     end


### PR DESCRIPTION
If the YAML file being read has anchors or similar additional syntax, the YAML gem includes these in the result so when loading values these may fail due to not having `:id` or `:type` values.

To solve this we have added a feature to exclude these blocks of YAML by including `_exclude_from_enumeration` in the key. These will get stripped out of the result before reading over the file.